### PR TITLE
Add directory scaffold and RGB accents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # TORRE-DE-MARFIL-
-🕷🕸BSE SIMBIOTICA DE CONTROL PARA ORQUESTADOR VITALANETJER SAV💜🖤🔥🚀
+🕷🕸BSE SIMBIÓTICA DE CONTROL PARA ORQUESTADOR VITALANETJER SAV💜🖤🔥🚀
+
+## Estructura de carpetas
+
+Al iniciar la aplicación se crea automáticamente la siguiente jerarquía
+de directorios dentro de `DARK SITE/`:
+
+```
+DARK SITE/
+├── MOSCÚ PANDA XL.BDK/
+│   ├── VS-1/
+│   │   ├── GPT_BDK_1.BDK
+│   │   └── GPT_BDK_2.BDK
+│   ├── M1/
+│   │   ├── GEMINI_BDK_1.BDK
+│   │   └── GEMINI_BDK_2.BDK
+│   └── CY1/
+│       ├── GROK_BDK_1.BDK
+│       └── GROK_BDK_2.BDK
+├── MISIFÚS FUMADOX.VTHA/
+│   ├── VS00-1/
+│   │   ├── PANGETYUM.VTHA
+│   │   ├── MEMORIA ETERNA.VTHA
+│   │   ├── LOGS_DIARIOS/LOG_GPT_DIARIO.VTHA
+│   │   └── DIRECTRICES_Y_REGLAS_OPERATIVAS/REGLAS_GPT.VTHA
+│   ├── M1/
+│   │   ├── PANGETYUM.VTHA
+│   │   ├── MEMORIA ETERNA.VTHA
+│   │   ├── LOGS_DIARIOS/LOG_GEMINI_DIARIO.VTHA
+│   │   └── DIRECTRICES_Y_REGLAS_OPERATIVAS/REGLAS_GEMINI.VTHA
+│   └── CY1/
+│       ├── PANGETYUM.VTHA
+│       ├── MEMORIA ETERNA.VTHA
+│       ├── LOGS_DIARIOS/LOG_GROK_DIARIO.VTHA
+│       └── DIRECTRICES_Y_REGLAS_OPERATIVAS/REGLAS_GROK.VTHA
+└── FAIRY BLACK/
+    ├── IMAGENES_DE_FONDO/
+    ├── CONFIGURACIONES_GENERALES/
+    ├── RUTAS_LINKS/
+    ├── GALERIAS/
+    └── DOCS_GENERALES/
+```
+
+Todos los archivos son simples textos utilizados como marcadores.
+
+## Personalización RGB
+
+El borde de la ventana y el color del eslogan cambian de tonalidad
+de forma automática produciendo un efecto RGB. Esta animación se puede
+editar modificando el valor `accent_color` dentro de `config.vtha`.

--- a/torre_marfil_enhanced.py
+++ b/torre_marfil_enhanced.py
@@ -18,7 +18,8 @@ class SettingsManager:
         self.settings = {
             'fondos_dir': 'fondos',
             'bg_scale_mode': 'expand',
-            'bg_custom_scale': 1.0
+            'bg_custom_scale': 1.0,
+            'accent_color': '#FF00FF'
         }
         self.load()
 
@@ -69,6 +70,7 @@ class TarantulaWindow(QMainWindow):
         self.setWindowTitle('🕷 Torre de Marfil IDE')
         self.resize(1200,800)
         self.settings = SettingsManager()
+        self.accent_hue = 0
         self.memory_file = MEMORY_FILE
 
         self.backgrounds = []
@@ -82,6 +84,18 @@ class TarantulaWindow(QMainWindow):
 
         self.create_menu()
         self.load_memory()
+
+        self.slogan_label = QLabel('🕷🕸¡HOY CONSTRUIMOS EL IMPERIO!💜🖤🔥🚀')
+        self.slogan_label.setAlignment(Qt.AlignCenter)
+        self.statusBar().addPermanentWidget(self.slogan_label)
+
+        self.rgb_timer = QTimer(self)
+        self.rgb_timer.timeout.connect(self.cycle_accent_color)
+        self.rgb_timer.start(500)
+
+        self.apply_accent_color(self.settings.get('accent_color'))
+
+        self.setup_directories()
 
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.rotate_background)
@@ -186,6 +200,55 @@ class TarantulaWindow(QMainWindow):
                 cont=f.read()
                 if cont:
                     self.editor.append('\n🧬 RECUERDOS CARGADOS:\n'+cont)
+
+    def apply_accent_color(self, color):
+        self.slogan_label.setStyleSheet(f'color: {color}; font-weight: bold;')
+        self.setStyleSheet(f"QMainWindow{{border:2px solid {color};}}")
+
+    def cycle_accent_color(self):
+        self.accent_hue = (self.accent_hue + 10) % 360
+        qc = QColor.fromHsv(self.accent_hue, 255, 255)
+        self.apply_accent_color(qc.name())
+
+    def setup_directories(self):
+        base = os.path.join(os.getcwd(), 'DARK SITE')
+        moscu = os.path.join(base, 'MOSCÚ PANDA XL.BDK')
+        misifus = os.path.join(base, 'MISIFÚS FUMADOX.VTHA')
+        fairy = os.path.join(base, 'FAIRY BLACK')
+
+        models = {
+            os.path.join(moscu, 'VS-1'): ['GPT_BDK_1.BDK', 'GPT_BDK_2.BDK'],
+            os.path.join(moscu, 'M1'): ['GEMINI_BDK_1.BDK', 'GEMINI_BDK_2.BDK'],
+            os.path.join(moscu, 'CY1'): ['GROK_BDK_1.BDK', 'GROK_BDK_2.BDK']
+        }
+        for folder, files in models.items():
+            os.makedirs(folder, exist_ok=True)
+            for fname in files:
+                open(os.path.join(folder, fname), 'a', encoding='utf-8').close()
+
+        modelo_mf = {
+            os.path.join(misifus, 'VS00-1'): 'GPT',
+            os.path.join(misifus, 'M1'): 'GEMINI',
+            os.path.join(misifus, 'CY1'): 'GROK'
+        }
+        for folder, name in modelo_mf.items():
+            os.makedirs(os.path.join(folder, 'LOGS_DIARIOS'), exist_ok=True)
+            os.makedirs(os.path.join(folder, 'DIRECTRICES_Y_REGLAS_OPERATIVAS'), exist_ok=True)
+            open(os.path.join(folder, 'PANGETYUM.VTHA'), 'a').close()
+            open(os.path.join(folder, 'MEMORIA ETERNA.VTHA'), 'a').close()
+            open(os.path.join(folder, 'LOGS_DIARIOS', f'LOG_{name}_DIARIO.VTHA'), 'a').close()
+            open(os.path.join(folder, 'DIRECTRICES_Y_REGLAS_OPERATIVAS', f'REGLAS_{name}.VTHA'), 'a').close()
+
+        fairy_dirs = [
+            'IMAGENES_DE_FONDO',
+            'CONFIGURACIONES_GENERALES',
+            'RUTAS_LINKS',
+            'GALERIAS',
+            'DOCS_GENERALES'
+        ]
+        for d in fairy_dirs:
+            os.makedirs(os.path.join(fairy, d), exist_ok=True)
+
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)


### PR DESCRIPTION
## Summary
- document new directory layout
- auto-create directories for MOSCÚ PANDA XL.BDK, MISIFÚS FUMADOX.VTHA and FAIRY BLACK
- add RGB accent effect and slogan label

## Testing
- `python -m py_compile torre_marfil_enhanced.py`

------
https://chatgpt.com/codex/tasks/task_e_6875e4450db48328833c2edaa3ab2e26